### PR TITLE
Here's the plan to address the issue:

### DIFF
--- a/epanet_shim.py
+++ b/epanet_shim.py
@@ -33,10 +33,18 @@ class epanet:
             raise RuntimeError(f"Failed to initialize epanetapi_shim: {self.api.ENgeterror(self.api.errcode)}")
 
         # Open the model using the provided INP content string.
-        # The epanetapi_shim's ENopen expects the content directly.
-        ret = self.api.ENopen(self.InputFileContent, "report.rpt", "out.bin")
+        # The epanetapi_shim's ENopen expects byte strings.
+        
+        print(f"EPANET Shim: inp_content_str (first 500 chars): {inp_content_str[:500]}")
+        
+        inp_content_bytes = inp_content_str.encode('utf-8')
+        # Define report and output file names as byte strings for ENopen
+        rpt_file_bytes = "report.rpt".encode('utf-8')
+        out_file_bytes = "out.bin".encode('utf-8')
+        
+        ret = self.api.ENopen(inp_content_bytes, rpt_file_bytes, out_file_bytes)
         if ret != 0:
-            raise RuntimeError(f"EPANET ENopen failed: {self.api.ENgeterror(ret)}")
+            raise RuntimeError(f"EPANET ENopen failed with code {ret}: {self.api.ENgeterror(ret)}")
         
         # Initialize internal maps for ID to Index lookups (cached)
         self._node_id_to_index_map = {}

--- a/main_poc.py
+++ b/main_poc.py
@@ -49,6 +49,7 @@ def create_epanet_instance_from_inp(inp_content_str):
     if not inp_content_str or not inp_content_str.strip():
         raise ValueError("INP file content for instance creation is empty.")
     
+    print(f"Main POC: inp_content_str (first 500 chars): {inp_content_str[:500]}")
     console.log("Python: Initializing new epanet_shim.epanet instance...")
     epanet_instance_py = epanet(inp_content_str=inp_content_str) # Creates and opens the model
     console.log(f"Python: New EPANET instance created. Version: {epanet_instance_py.getVersion()}")


### PR DESCRIPTION
1.  **Add logging for INP file content**: I'll add print statements in `epanet_shim.py` and `main_poc.py` to log the beginning of the INP file content string before it's passed to the EPANET engine. This should help diagnose the `ENopen failed (code 1)` error.