### PR TITLE
Fix: Ensure loaded EPANET INP file is used for rendering.

### DIFF
--- a/main_poc.py
+++ b/main_poc.py
@@ -73,7 +73,7 @@ def create_epanet_instance_from_inp(inp_content_str):
     if not inp_content_str or not inp_content_str.strip():
         raise ValueError("INP file content for instance creation is empty.")
     
-    inp_content_str = "[TITLE]\nMinimal Test\n[JUNCTIONS]\nJ1 0 0\n[PIPES]\n[END]"
+    # inp_content_str = "[TITLE]\nMinimal Test\n[JUNCTIONS]\nJ1 0 0\n[PIPES]\n[END]"
     print(f"Main POC: inp_content_str (first 500 chars): {inp_content_str[:500]}")
     console.log("Python: Initializing new epanet_shim.epanet instance...")
     epanet_instance_py = epanet(inp_content_str=inp_content_str) # Creates and opens the model


### PR DESCRIPTION
This commit addresses an issue where the web application would always render a hardcoded minimal EPANET network instead of the .INP file loaded by you. This was due to a line in \`main_poc.py\` that overwrote the input file content. This line has now been commented out.

Additionally, I reviewed the version management logic. The expected versions in \`script.js\` align with the actual versions provided by the Python backend, so no changes to version strings were necessary. The version checking mechanism and cache busting are functioning as intended.

I recommend you manually test the EPANET rendering with a user-provided .INP file and the version display on the webpage to confirm the fixes.