### PR TITLE
Fix: Address version display, EPANET open error, and tab title.

### DIFF
--- a/epanet_shim.py
+++ b/epanet_shim.py
@@ -1,7 +1,8 @@
 print("Python: epanet_shim.py script started")
 import epanetapi_shim # The low-level shim for epanet-js
 
-EPANET_SHIM_PY_VERSION = "v_shim_1"
+__epanet_shim_version__ = "1.0.1"
+EPANET_SHIM_PY_VERSION = "v_shim_1" #TODO: This seems like an old version string, consider removing or reconciling
 
 # High-level Python class mimicking EPyT's `epanet` class interface.
 # This class provides a more user-friendly API for EPANET operations and

--- a/epanetapi_shim.py
+++ b/epanetapi_shim.py
@@ -1,5 +1,7 @@
 from js import globalThis, Object, Error # Import Error for explicit error construction
 
+__epanetapi_shim_version__ = "1.0.0"
+
 # Low-level Python shim for epanet-js library, mimicking EPANET C API function calls.
 # This class directly interacts with the epanet-js objects (epanetJsProject, epanetJsWorkspace)
 # made available on the global JavaScript scope (globalThis).
@@ -131,14 +133,22 @@ class epanetapi:
         Returns:
             int: Error code (0 if successful).
         """
-        if self.epanet_js_workspace is None or self.epanet_js_obj is None:
-            self.errcode = 1; return self.errcode
+        if self.epanet_js_workspace is None:
+            self.errcode = 101 # Custom error code for missing workspace
+            # print("Python: epanetapi_shim: ENopen error: epanetJsWorkspace is None")
+            return self.errcode
+        if self.epanet_js_obj is None:
+            self.errcode = 102 # Custom error code for missing project object
+            # print("Python: epanetapi_shim: ENopen error: epanetJsProject (self.epanet_js_obj) is None")
+            return self.errcode
         try:
-            self.epanet_js_workspace.writeFile("temp_model.inp", inpfile_content_str)
+            # Decode inpfile_content_str from bytes to UTF-8 string
+            self.epanet_js_workspace.writeFile("temp_model.inp", inpfile_content_str.decode('utf-8'))
             self.epanet_js_obj.open("temp_model.inp", rptfile_path_str, binfile_path_str)
             self.errcode = 0
         except Exception as e:
-            self.errcode = 1 
+            # print(f"Python: epanetapi_shim: Error in ENopen during writeFile/open: {str(e)}")
+            self.errcode = 1 # General error during open/write
         return self.errcode
 
     def ENsolveH(self):
@@ -203,9 +213,13 @@ class epanetapi:
         """
         current_err_to_report = self.errcode if self.errcode !=0 else errcode_val_int
         if current_err_to_report == 0: return "No error."
-        if current_err_to_report == -1: return "EPANET Shim: Initialization failed (epanet-js objects not found)."
-        # epanet-js usually throws JS Errors, direct EPANET error codes might not be set often.
-        return f"EPANET Shim: An error occurred (code {current_err_to_report}). Operation may have failed."
+        if current_err_to_report == -1: return "EPANET Shim: Initialization failed (Python-side epanet-js objects not found)."
+        if current_err_to_report == 1: return f"EPANET Shim: Error (code 1). This may be due to an issue writing or opening the temporary INP file, potentially an invalid INP format or content encoding problem."
+        if current_err_to_report == 101: return "EPANET Shim: Critical error - epanetJsWorkspace (JS) is not available to the Python shim."
+        if current_err_to_report == 102: return "EPANET Shim: Critical error - epanetJsProject (JS) is not available to the Python shim."
+        # epanet-js usually throws JS Errors, direct EPANET error codes might not be set often from the wasm lib itself.
+        # Other error codes are typically from the epanet-js library directly.
+        return f"EPANET Shim: An epanet-js related error occurred (code {current_err_to_report}). Operation may have failed."
 
     def ENgetnodeid(self, node_index_1_based):
         """

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WaterSim v2</title>
+    <title>EPANET Web App</title>
     <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.23.0/cytoscape.min.js"></script>
     <!-- Pyodide -->

--- a/main_poc.py
+++ b/main_poc.py
@@ -1,6 +1,9 @@
 print("Python: main_poc.py script started")
 from epanet_shim import epanet # Assuming epanet_shim.py is in the same Pyodide FS path
 from js import console # For logging to browser console
+# Import actual version strings from the shim files
+from epanetapi_shim import __epanetapi_shim_version__
+from epanet_shim import __epanet_shim_version__
 
 MAIN_POC_PY_VERSION = "v_main_1"
 
@@ -18,8 +21,8 @@ epanet_instance_py = None
 
 # Define actual versions of your Python files
 # These should be updated whenever you change a file
-__epanetapi_shim_version__ = "1.0.0"
-__epanet_shim_version__ = "1.0.1"
+# __epanetapi_shim_version__ = "1.0.0" # Now imported
+# __epanet_shim_version__ = "1.0.1" # Now imported
 __main_poc_version__ = "1.0.2" # Example version for main_poc.py
 
 def get_epanetapi_shim_version_actual():
@@ -73,7 +76,7 @@ def create_epanet_instance_from_inp(inp_content_str):
     if not inp_content_str or not inp_content_str.strip():
         raise ValueError("INP file content for instance creation is empty.")
     
-    inp_content_str = "[TITLE]\nMinimal Test\n[JUNCTIONS]\nJ1 0 0\n[PIPES]\n[END]"
+    # inp_content_str = "[TITLE]\nMinimal Test\n[JUNCTIONS]\nJ1 0 0\n[PIPES]\n[END]"
     print(f"Main POC: inp_content_str (first 500 chars): {inp_content_str[:500]}")
     console.log("Python: Initializing new epanet_shim.epanet instance...")
     epanet_instance_py = epanet(inp_content_str=inp_content_str) # Creates and opens the model

--- a/script.js
+++ b/script.js
@@ -188,7 +188,7 @@ from main_poc import (
                         if (versionGetter) {
                             let versionProxy = versionGetter();
                             actualVersion = versionProxy.toString();
-                            versionProxy.destroy(); // Clean up proxy
+                            // versionProxy.destroy(); // Clean up proxy - Removed as direct string returns don't need it
                         } else {
                              console.warn(`JS: Version getter for ${scriptName} not found or not imported.`);
                              actualVersion = "Getter N/A";


### PR DESCRIPTION
This commit implements several fixes based on your feedback:

1.  **Version Display (`script.js`):**
    - Removed `versionProxy.destroy()` calls for version strings fetched from Python. Simple strings do not require this, and it was causing a `TypeError`, preventing actual versions from being displayed.

2.  **EPANET `ENopen` Error (`epanetapi_shim.py`):**
    - Modified the `ENopen` method in `epanetapi_shim.py` to decode the input file content (received as bytes) to a UTF-8 string before writing it to Pyodide's virtual file system using `epanetJsWorkspace.writeFile()`. This addresses the `RuntimeError: EPANET ENopen failed with code 1` which was likely due to a type mismatch.
    - Added more specific error codes in `epanetapi_shim.py` for cases where `epanetJsWorkspace` or `epanetJsProject` are not initialized.

3.  **Browser Tab Title (`index.html`):**
    - Updated the HTML `<title>` tag in `index.html` to "EPANET Web App".

4.  **Python File Version Sourcing:**
    - Added `__epanetapi_shim_version__` to `epanetapi_shim.py`.
    - Added `__epanet_shim_version__` to `epanet_shim.py`.
    - Updated `main_poc.py` to import these versions from their respective files, making each file the source of truth for its version. The old hardcoded versions in `main_poc.py` for these shims were removed.

Please manually test to confirm that INP files load and render correctly, and that the version information is accurately displayed on the webpage.