### PR TITLE
Fix: Sanitize INP file content before processing.

### DIFF
--- a/epanet_shim.py
+++ b/epanet_shim.py
@@ -46,6 +46,21 @@ class epanet:
         self.rpt_file = ""
         self.out_file = ""
         
+        # Sanitize INP file content
+        lines = inp_content_str.splitlines()
+        sanitized_lines = []
+        for line in lines:
+            # Normalize line endings (already handled by splitlines, but good for clarity)
+            # Trim leading/trailing whitespace from each line
+            sanitized_line = line.strip()
+            sanitized_lines.append(sanitized_line)
+        # Reconstruct the content, ensuring newline characters are '
+'
+        inp_content_str = "\n".join(sanitized_lines)
+
+        # Add a print statement to log the sanitized content for verification (optional, for debugging)
+        # print(f"EPANET Shim: Sanitized inp_content_str (first 500 chars): {inp_content_str[:500]}")
+        
         inp_content_bytes = inp_content_str.encode('utf-8')
         # Define report and output file names as byte strings for ENopen
         rpt_file_bytes = self.rpt_file.encode('utf-8')


### PR DESCRIPTION
This commit addresses the "ENopen failed with code 1" error that occurred when loading INP files. The issue persisted even after ensuring correct string encoding.

The fix involves sanitizing the INP file content string within `epanet_shim.py` before it's passed to the `epanet-js` library. The sanitization includes:
- Normalizing line endings to LF (\n).
- Trimming leading and trailing whitespace from each line.

This preprocessing aims to provide a cleaner and more consistent INP format to `epanet-js`, mitigating potential parsing issues related to varied line endings or extraneous whitespace that might have caused the `open` operation to fail.

The investigation confirmed that `epanet-js` requires opening models via a filename from its virtual workspace, so direct string input was not an option.

Manual testing is needed to confirm this resolves the rendering issue.