### PR TITLE
Fix: Correct SyntaxError in epanet_shim.py.

### DIFF
--- a/epanet_shim.py
+++ b/epanet_shim.py
@@ -54,8 +54,7 @@ class epanet:
             # Trim leading/trailing whitespace from each line
             sanitized_line = line.strip()
             sanitized_lines.append(sanitized_line)
-        # Reconstruct the content, ensuring newline characters are '
-'
+        # Reconstruct the content, ensuring newline characters are '\n'
         inp_content_str = "\n".join(sanitized_lines)
 
         # Add a print statement to log the sanitized content for verification (optional, for debugging)


### PR DESCRIPTION
This commit fixes an `SyntaxError: unterminated string literal` in `epanet_shim.py`. The error was caused by a malformed comment and an extraneous single quote character introduced during a previous modification for INP file content sanitization.

The problematic comment has been corrected, and the stray quote character has been removed. This allows `epanet_shim.py` to be parsed correctly, enabling the application to initialize and operate as intended.

This fix is crucial for the subsequent INP file processing and rendering logic to function.