### PR TITLE
Fix: Correct INP file string handling and enhance logging

### DIFF
--- a/epanet_shim.py
+++ b/epanet_shim.py
@@ -24,6 +24,7 @@ class epanet:
             TypeError: If inp_content_str is not a string.
             RuntimeError: If the underlying epanetapi_shim fails to initialize or open the INP file.
         """
+        print(f"Python: epanet_shim.py version {__epanet_shim_version__} loaded.")
         # print("Python: epanet_shim: __init__ called.")
         if not isinstance(inp_content_str, str):
             raise TypeError("inp_content_str must be a string containing the INP file data.")

--- a/epanetapi_shim.py
+++ b/epanetapi_shim.py
@@ -1,6 +1,6 @@
 from js import globalThis, Object, Error # Import Error for explicit error construction
 
-__epanetapi_shim_version__ = "1.0.1"
+__epanetapi_shim_version__ = "1.0.2"
 
 # Low-level Python shim for epanet-js library, mimicking EPANET C API function calls.
 # This class directly interacts with the epanet-js objects (epanetJsProject, epanetJsWorkspace)
@@ -142,8 +142,9 @@ class epanetapi:
             # print("Python: epanetapi_shim: ENopen error: epanetJsProject (self.epanet_js_obj) is None")
             return self.errcode
         try:
-            # Decode inpfile_content_str from bytes to UTF-8 string
-            self.epanet_js_workspace.writeFile("temp_model.inp", inpfile_content_str.decode('utf-8'))
+            print("Python [ENopen]: Attempting self.epanet_js_workspace.writeFile...")
+            self.epanet_js_workspace.writeFile("temp_model.inp", inpfile_content_str)
+            print("Python [ENopen]: self.epanet_js_workspace.writeFile successful.")
             try:
                 written_content = self.epanet_js_workspace.readFile("temp_model.inp")
                 print(f"Python [ENopen Investigation]: Content read back from virtual file (first 300 chars): {written_content[:300]}")
@@ -152,10 +153,12 @@ class epanetapi:
                 #     print("Python [ENopen Investigation]: WARNING - Content read back differs from content written!")
             except Exception as e_read:
                 print(f"Python [ENopen Investigation]: ERROR reading back temp_model.inp: {str(e_read)}")
+            print("Python [ENopen]: Attempting self.epanet_js_obj.open...")
             self.epanet_js_obj.open("temp_model.inp", rptfile_path_str, binfile_path_str)
+            print("Python [ENopen]: self.epanet_js_obj.open successful.")
             self.errcode = 0
         except Exception as e:
-            # print(f"Python: epanetapi_shim: Error in ENopen during writeFile/open: {str(e)}")
+            print(f"Python [ENopen]: Exception caught in ENopen: {type(e).__name__}: {str(e)}")
             self.errcode = 1 # General error during open/write
         return self.errcode
 

--- a/main_poc.py
+++ b/main_poc.py
@@ -24,6 +24,7 @@ epanet_instance_py = None
 # __epanetapi_shim_version__ = "1.0.0" # Now imported
 # __epanet_shim_version__ = "1.0.1" # Now imported
 __main_poc_version__ = "1.0.3" # Example version for main_poc.py
+print(f"Python: main_poc.py version {__main_poc_version__} loaded.")
 
 def get_epanetapi_shim_version_actual():
     return __epanetapi_shim_version__

--- a/script.js
+++ b/script.js
@@ -81,7 +81,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // These are the versions you expect to be loaded.
     // You might update these as you deploy new versions of your Python files.
     const expectedFileVersions = {
-        'epanetapi_shim.py': '1.0.1',
+        'epanetapi_shim.py': '1.0.2',
         'epanet_shim.py': '1.0.2',
         'main_poc.py': '1.0.3' // Make sure this matches the version in main_poc.py
     };


### PR DESCRIPTION
This commit addresses an issue in `epanetapi_shim.py` where an `AttributeError` would occur due to an incorrect `.decode('utf-8')` call on a string variable when preparing to write the INP file content. This call has been removed.

Additional logging has been added to `epanetapi_shim.py`'s `ENopen` method:
- Print statements before and after `epanetJsWorkspace.writeFile()`
- Print statements before and after `epanetJsProject.open()`
- More specific exception details if an error occurs within `ENopen`.

Version updates:
- `epanetapi_shim.py` version incremented to `1.0.2`.
- `script.js` updated to expect `epanetapi_shim.py` version `1.0.2`.

Informational logging:
- Added print statements to log the loaded versions of `epanet_shim.py` (v1.0.2) and `main_poc.py` (v1.0.3) upon their initialization.

These changes should resolve the `EPANET ENopen failed with code 1` error if it was caused by the string decoding issue, and provide better diagnostics for future troubleshooting.